### PR TITLE
Replace tooltiptext with updated dynamic tooltip.

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -69,7 +69,7 @@
                            onclick="checkForMiddleClick(this, event);"
                            onmouseover="document.getBindingParent(this)._enterNewTab();"
                            onmouseout="document.getBindingParent(this)._leaveNewTab();"
-                           tooltiptext="&newTabButton.tooltip;"/>
+                           tooltip="dynamic-shortcut-tooltip"/>
         <xul:spacer class="closing-tabs-spacer" anonid="closing-tabs-spacer"
                     style="width: 0;"/>
       </xul:arrowscrollbox>


### PR DESCRIPTION
Bug 979479 added dynamic tooltips, including keyboard shortcuts, to
various buttons; this change needs to be reflected in the overridden
XUL.  Before updating, this manifested itself as tabs overlaid on each
other, and the error message "undefined entity" (referring to the old
tooltiptext).

See http://hg.mozilla.org/mozilla-central/rev/4dc06a48ed13.
