### PR TITLE
"Part fix" for the most prominent part of background overwrite issue

### DIFF
--- a/skin/win7/win7.css
+++ b/skin/win7/win7.css
@@ -29,8 +29,6 @@
 .tabbrowser-tab {
     -moz-box-pack: start;
     -moz-box-flex: 0;
-    -moz-appearance: none ! important;
-    background: transparent ! important;
 
     border: 1px solid transparent;
     border-radius: 2.67px 0 0 2.67px;


### PR DESCRIPTION
See issue #13 5 Nov 2014 for background:  https://github.com/darrinhenein/VerticalTabs/issues/13

The extension also kills any other extension's attempt to manage tab background colours.  Various extensions like Tab Mix Plus and ColorfulTabs control tab backgrounds, to show tab status or domain etc. VT just deletes all these and overrides them, with what it considers "default colours". 

Two problems - 
1) a user can't colour tabs for status etc if also using VT
2) VT doesn't have any place doing this - a user who wants to theme their tabs, can use themes, or a customisation extension. It's completely separate from vertical formatting the tab. 

Too hard to unpick everything but this fix at least stops VT killing the major part of other extensions colouring, on Windows.  Ideally please remove _all_ tab theming from VT. Let other extensions do theming, if a user wants a theme, and don't override them.  
